### PR TITLE
Fix misuse of `getStackInSlot`

### DIFF
--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
@@ -324,7 +324,7 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
      * @param slot      The inventory slot of the item.
      */
     private void sendDrone(ItemStack itemStack, int slot) {
-        if (roboBeeInventory.getStackInSlot(0).getCount() <= 0) {
+        if (!tryConsumeDrone()) {
             if (this.entityOnTravel == null) {
                 requestRoboEntity(level, this.getBlockPos());
                 return;
@@ -335,18 +335,25 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
         RoboBeeEntity drone = new RoboBeeEntity(level, itemStack, null, this.getBlockPos());
         level.addFreshEntity(drone);
         drone.setRequest(false);
-        roboBeeInventory.getStackInSlot(0).shrink(1);
         inventory.setStackInSlot(slot, ItemStack.EMPTY);
     }
     private void sendDrone(BlockPos tagetPos, boolean request) {
-        if (this.roboBeeInventory.getStackInSlot(0).getCount() <= 0) {
+        if (!tryConsumeDrone())
             return;
-        }
         sendItemThisTime = 2;
         RoboBeeEntity drone = new RoboBeeEntity(level, ItemStack.EMPTY, tagetPos, this.getBlockPos());
         level.addFreshEntity(drone);
         drone.setRequest(request);
-        roboBeeInventory.getStackInSlot(0).shrink(1);
+    }
+
+    /**
+     * Tries to remove a drone from the inventory.
+     * 
+     * @return whether a drone was available
+     */
+    private boolean tryConsumeDrone() {
+        ItemStack usedBee = roboBeeInventory.extractItem(0, 1, false);
+        return !usedBee.isEmpty();
     }
 
     /**


### PR DESCRIPTION
The documentation on `getStackInSlot` warns against modifying the inventory this way:

![Screenshot of `getStackInSlot` method documentation](https://github.com/user-attachments/assets/e848a680-e3ca-4a26-89f9-004636224f0e)

I think `extractItem` is the most sensible alternative.

Potentially fixes #183.