### PR TITLE
Fix duplication of bee port block entities

### DIFF
--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
@@ -286,6 +286,7 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     private static void requestRoboEntity(Level level, BlockPos blockPos) {
         level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> {
             List<BeePortBlockEntity> allBEs = new ArrayList<>(tracker.getAll());
+            allBEs.removeIf(be -> be.isRemoved());
             allBEs.removeIf(be -> be.getBlockPos().equals(blockPos));
             allBEs.removeIf(be -> be.getRoboBeeInventory().getStackInSlot(0).getCount() <= 0);
             BeePortBlockEntity target = allBEs.stream()
@@ -434,19 +435,50 @@ public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
     }
 
     /**
-     * Called when the block entity is removed. Unregisters the entity from the tracker.
+     * Unregisters the entity from the tracker and halts any incoming bees.
      */
+    private void invalidateTarget() {
+        level
+            .getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP)
+            .ifPresent(tracker -> tracker.remove(this));
+
+        if (entityOnTravel != null) {
+            entityOnTravel.setTargetVelocity(Vec3.ZERO);
+            entityOnTravel.setState(new AdjustRotationToTarget());
+        }
+    }
+
+    /**
+     * Meant to be called when the bee port is broken. Drops any bees from the
+     * inventory. Does not update the inventory.
+     */
+    private void dropBees() {
+        ItemStack bees = roboBeeInventory.getStackInSlot(0);
+
+        if (bees.getCount() > 0) {
+            level.addFreshEntity(new ItemEntity(
+                level,
+                worldPosition.getX(),
+                worldPosition.getY(),
+                worldPosition.getZ(),
+                bees
+            ));
+        }
+    }
+
+    @Override
+    public void onChunkUnloaded() {
+        if (!level.isClientSide) {
+            this.invalidateTarget();
+        }
+        super.onChunkUnloaded();
+    }
+
     @Override
     public void remove() {
         if (!level.isClientSide) {
-            level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> tracker.remove(this));
-            if (entityOnTravel != null) {
-                entityOnTravel.setTargetVelocity(Vec3.ZERO);
-                entityOnTravel.setState(new AdjustRotationToTarget());
-            }
-            if (roboBeeInventory.getStackInSlot(0).getCount() > 0) {
-                level.addFreshEntity(new ItemEntity(level, worldPosition.getX(), worldPosition.getY(), worldPosition.getZ(), roboBeeInventory.getStackInSlot(0)));
-            }
+            this.invalidateTarget();
+            this.dropBees();
         }
         super.remove();
     }

--- a/src/main/java/de/theidler/create_mobile_packages/entities/robo_entity/RoboEntity.java
+++ b/src/main/java/de/theidler/create_mobile_packages/entities/robo_entity/RoboEntity.java
@@ -122,7 +122,12 @@ public class RoboEntity extends Mob {
         if (level().isClientSide) { return; }
         targetPlayer = getTargetPlayerFromAddress();
         if (targetPlayer != null) { return; }
-        if (targetBlockEntity == null || !targetBlockEntity.canAcceptEntity(this, !getItemStack().isEmpty()) || !Objects.equals(activeTargetAddress,targetAddress)) {
+        if (
+            targetBlockEntity == null ||
+            targetBlockEntity.isRemoved() ||
+            !targetBlockEntity.canAcceptEntity(this, !getItemStack().isEmpty()) ||
+            !Objects.equals(activeTargetAddress,targetAddress)
+        ) {
             BeePortBlockEntity oldTarget = targetBlockEntity;
             activeTargetAddress = targetAddress;
             targetBlockEntity = getClosestBeePort(level(), Objects.equals(targetAddress, "") ? null : targetAddress, this.blockPosition(), this);
@@ -190,6 +195,7 @@ public class RoboEntity extends Mob {
         final BeePortBlockEntity[] closest = {null};
         level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> {
             List<BeePortBlockEntity> allBEs = new ArrayList<>(tracker.getAll());
+            allBEs.removeIf(be -> be.isRemoved());
             allBEs.removeIf(dpbe -> !isWithinRange(dpbe.getBlockPos(), origin));
             if (address != null) {
                 allBEs.removeIf(dpbe -> !PackageItem.matchAddress(address, dpbe.addressFilter));


### PR DESCRIPTION
Fixes #183, hopefully for real this time.

When you move far enough away from a bee port that the chunk gets unloaded, its block entity never gets removed from `BeePortEntityTracker`. This means other ports can still request bees from it. When you go back, Minecraft loads a new copy of the block entity and this causes duplication of the bees.

To avoid duplication, we need to satisfy two things:

1. When `isRemoved()` on a block entity returns `true`, this copy is not part of the world any more and should not be interacted with in any way (these entities automatically stop ticking). It might be added back later, so we can't forget about it yet.
2. When `onChunkUnloaded()` is called on a block entity, this copy is not part of the world any more and is definitely not coming back, so we can forget about it.

Note that this means bees will no longer be able to head towards ports in unloaded chunks. If a port is unloaded while a bee is partway there, it will now stop, and try to find another matching target which is loaded, or otherwise wait at its current position until the port is available again.

Supporting this properly would require holding onto the full details of each port (its position, name, inventory, and bee count) and saving that globally. You then have to switch between using the entity and the global data depending on whether the entity is currently loaded or not. Take a look at how the main Create mod does it with postboxes, although note that their current code has bugs like https://github.com/Creators-of-Create/Create/issues/7491.

Also, I noticed that `DronePortTracker` was renamed on `mc1.20.1/dev` but not on `mc1.21.1/dev`, and some of its code is also different. You might want to look into that :))