### PR TITLE
Logistics Network Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 ------------------------------------------------------
+Create: Mobile Packages - v0.6.0 - unreleased
+------------------------------------------------------
+
+### Breaking Changes
+#### Logistics Network support
+
+**Warning! This will break all existing ports. They need to be replaced to link to a logistics network!**
+
+- link a bee port to a logistics network or place one to create a new one
+- bees will only fly to bee ports within their network.
+- the bee item can be linked to a logistics network
+- if a bee item is not connected to a network, then the bee will fly to any port (closest)
+
+------------------------------------------------------
 Create: Mobile Packages - v0.5.5 - 13.07.2025
 ------------------------------------------------------
 

--- a/src/main/java/de/theidler/create_mobile_packages/CMPHelper.java
+++ b/src/main/java/de/theidler/create_mobile_packages/CMPHelper.java
@@ -14,6 +14,7 @@ import net.minecraft.world.phys.Vec3;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 
 public class CMPHelper {
 
@@ -49,19 +50,21 @@ public class CMPHelper {
      * @param address The address to filter by, or {@code null} for no filtering.
      * @return The closest BeePortBlockEntity that matches the filter criteria, or {@code null} if none found.
      */
-    public static BeePortBlockEntity getClosestBeePort(Level level, String address, BlockPos origin, VirtualRobo entity) {
+    public static BeePortBlockEntity getClosestBeePort(Level level, String address, BlockPos origin, VirtualRobo entity, UUID logisticsNetworkId) {
         final BeePortBlockEntity[] closest = {null};
         level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> {
-            List<BeePortBlockEntity> allBEs = new ArrayList<>(tracker.getAll());
+            List<BeePortBlockEntity> allBEs = new ArrayList<>(tracker.getAllByNetwork(logisticsNetworkId));
+            if (allBEs.isEmpty()) {
+                // if there are no Bee Ports in the network, then allow the bee to fly to any network
+                allBEs.addAll(tracker.getAll());
+            }
             allBEs.removeIf(BlockEntity::isRemoved);
             allBEs.removeIf(dpbe -> !isWithinRange(dpbe.getBlockPos(), origin));
             if (address != null) {
                 allBEs.removeIf(dpbe -> !PackageItem.matchAddress(address, dpbe.addressFilter));
             }
             allBEs.removeIf(dpbe -> !dpbe.canAcceptEntity(entity, (entity != null && !entity.getItemStack().isEmpty())));
-            closest[0] = allBEs.stream()
-                    .min(Comparator.comparingDouble(a -> a.getBlockPos().distSqr(origin)))
-                    .orElse(null);
+            closest[0] = allBEs.stream().min(Comparator.comparingDouble(a -> a.getBlockPos().distSqr(origin))).orElse(null);
         });
         return closest[0];
     }

--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlock.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlock.java
@@ -1,6 +1,7 @@
 package de.theidler.create_mobile_packages.blocks.bee_port;
 
 import com.simibubi.create.content.equipment.wrench.IWrenchable;
+import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBlockItem;
 import com.simibubi.create.foundation.block.IBE;
 import de.theidler.create_mobile_packages.index.CMPBlockEntities;
 import de.theidler.create_mobile_packages.index.CMPBlocks;
@@ -82,8 +83,10 @@ public class BeePortBlock extends Block implements IBE<BeePortBlockEntity>, IWre
     }
 
     @Override
-    public InteractionResult use(BlockState state, Level worldIn, BlockPos pos, Player player, InteractionHand handIn,
-                                 BlockHitResult hit) {
+    public InteractionResult use(BlockState state, Level worldIn, BlockPos pos, Player player, InteractionHand handIn, BlockHitResult hit) {
+        if (player.getItemInHand(handIn).getItem() instanceof LogisticallyLinkedBlockItem)
+            return InteractionResult.PASS;
+
         return onBlockEntityUse(worldIn, pos, be -> be.use(player));
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
@@ -3,6 +3,8 @@ package de.theidler.create_mobile_packages.blocks.bee_port;
 import com.simibubi.create.content.logistics.box.PackageItem;
 import com.simibubi.create.content.logistics.packagePort.PackagePortBlockEntity;
 import com.simibubi.create.content.logistics.packagePort.frogport.FrogportBlockEntity;
+import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBehaviour;
+import com.simibubi.create.foundation.blockEntity.behaviour.BlockEntityBehaviour;
 import de.theidler.create_mobile_packages.CMPHelper;
 import de.theidler.create_mobile_packages.CreateMobilePackages;
 import de.theidler.create_mobile_packages.entities.robo_entity.states.AdjustRotationToTarget;
@@ -42,8 +44,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
-import static de.theidler.create_mobile_packages.blocks.bee_port.BeePortBlock.IS_OPEN_TEXTURE;
 import static de.theidler.create_mobile_packages.CMPHelper.calcETA;
+import static de.theidler.create_mobile_packages.blocks.bee_port.BeePortBlock.IS_OPEN_TEXTURE;
 
 /**
  * Represents a Drone Port block entity that handles the processing and sending of Create Mod packages
@@ -120,10 +122,10 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
             }
         }
     };
+    public LogisticallyLinkedBehaviour behaviour;
     private int tickCounter = 0; // Counter to track ticks for periodic processing.
     private int sendItemThisTime = 0; // Flag to indicate if an item was sent this time.
     private UUID entityOnTravelID;
-    private final UUID logisticsNetworkId = UUID.randomUUID(); // TODO: implement
 
     /**
      * Constructor for the BeePortBlockEntity.
@@ -135,6 +137,69 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     public BeePortBlockEntity(BlockEntityType<?> pType, BlockPos pPos, BlockState pBlockState) {
         super(pType, pPos, pBlockState);
         itemHandler = LazyOptional.of(() -> handler);
+    }
+
+    public static boolean doesAddressStringMatchPlayerName(Player player, String address) {
+        String playerName = player.getName().getString();
+        int atIndex = address.lastIndexOf('@');
+        if (atIndex == -1) {
+            return address.equals(playerName);
+        }
+        return address.substring(atIndex + 1).equals(playerName);
+    }
+
+    private static void requestRoboEntity(Level level, BlockPos blockPos, UUID logisticsNetworkId) {
+        level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> {
+            List<BeePortBlockEntity> allBEs = new ArrayList<>(tracker.getAllByNetwork(logisticsNetworkId));
+            allBEs.removeIf(BlockEntity::isRemoved);
+            allBEs.removeIf(be -> be.getBlockPos().equals(blockPos));
+            allBEs.removeIf(be -> be.getRoboBeeInventory().getStackInSlot(0).getCount() <= 0);
+            allBEs.stream().min(Comparator.comparingDouble(a -> a.getBlockPos().distSqr(blockPos))).ifPresent(target -> target.sendDrone(blockPos, true));
+        });
+    }
+
+    /**
+     * Sets the open state of the drone port and updates the block state and sound.
+     *
+     * @param entity The drone port entity.
+     * @param open   Whether the port is open.
+     */
+    public static void setOpen(BeePortBlockEntity entity, boolean open) {
+        if (entity == null || entity.level == null) return;
+
+        entity.level.setBlockAndUpdate(entity.getBlockPos(), entity.getBlockState().setValue(IS_OPEN_TEXTURE, open));
+        entity.level.playSound(null, entity.getBlockPos(), open ? SoundEvents.BARREL_OPEN : SoundEvents.BARREL_CLOSE, SoundSource.BLOCKS);
+
+    }
+
+    /**
+     * Checks if the player's inventory is full.
+     *
+     * @param player The player to check.
+     * @return True if the inventory is full, false otherwise.
+     */
+    public static boolean isPlayerInventoryFull(Player player) {
+        return player.getInventory().items.stream().limit(player.getInventory().getContainerSize() - 5).noneMatch(ItemStack::isEmpty);
+    }
+
+    /**
+     * Sends a Create Mod package to a player. If the player's inventory is full, the item is not added.
+     *
+     * @param player    The player to send the package to. Must not be null.
+     * @param itemStack The Create Mod package to send. Must not be empty.
+     * @return True if the package was successfully sent to the player, false otherwise.
+     */
+    public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
+        if (player == null || itemStack.isEmpty()) {
+            return false;
+        }
+        player.displayClientMessage(Component.translatableWithFallback("create_mobile_packages.bee_port.send_items", "Send Items to Player"), true);
+
+        if (isPlayerInventoryFull(player)) {
+            return false;
+        }
+        player.getInventory().add(itemStack);
+        return true;
     }
 
     @Override
@@ -170,6 +235,12 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     }
 
     @Override
+    public void addBehaviours(List<BlockEntityBehaviour> behaviours) {
+        behaviours.add(behaviour = new LogisticallyLinkedBehaviour(this, true));
+        super.addBehaviours(behaviours);
+    }
+
+    @Override
     public void lazyTick() {
         super.lazyTick();
         if (level == null || level.isClientSide()) return;
@@ -193,8 +264,7 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
         for (IItemHandler adjacentInventory : getAdjacentInventories()) {
             for (int i = 0; i < inventory.getSlots(); i++) {
                 ItemStack stackInSlot = inventory.extractItem(i, 1, true);
-                if (stackInSlot.isEmpty())
-                    continue;
+                if (stackInSlot.isEmpty()) continue;
                 ItemStack remainder = ItemHandlerHelper.insertItemStacked(adjacentInventory, stackInSlot, false);
                 if (remainder.isEmpty() && level != null) {
                     inventory.extractItem(i, 1, false);
@@ -208,9 +278,9 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
         VirtualRobo currentEntity = this.getRoboEntity();
         if (hasFullInventory(currentEntity != null ? 1 : 0)) return;
 
-        getAdjacentInventories().forEach(( inventory) -> {
+        getAdjacentInventories().forEach((inventory) -> {
             if (inventory == null) return;
-            if (hasFullInventory(currentEntity != null  ? 1 : 0)) return;
+            if (hasFullInventory(currentEntity != null ? 1 : 0)) return;
             for (int i = 0; i < inventory.getSlots(); i++) {
                 ItemStack itemStack = inventory.getStackInSlot(i);
                 if (!itemStack.isEmpty() && PackageItem.isPackage(itemStack)) {
@@ -230,13 +300,12 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
         }
         return inventories;
     }
+
     private IItemHandler getAdjacentInventory(Direction side) {
         if (level == null) return null;
         BlockEntity blockEntity = level.getBlockEntity(worldPosition.relative(side));
-        if (blockEntity == null || blockEntity instanceof FrogportBlockEntity)
-            return null;
-        return blockEntity.getCapability(ForgeCapabilities.ITEM_HANDLER, side.getOpposite())
-                .orElse(null);
+        if (blockEntity == null || blockEntity instanceof FrogportBlockEntity) return null;
+        return blockEntity.getCapability(ForgeCapabilities.ITEM_HANDLER, side.getOpposite()).orElse(null);
     }
 
     /**
@@ -268,8 +337,7 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
 
         // Check if the item can be sent to a player.
         for (Player player : level.players()) {
-            if (doesAddressStringMatchPlayerName(player, address)
-                    && CMPHelper.isWithinRange(player.blockPosition(), this.getBlockPos())) {
+            if (doesAddressStringMatchPlayerName(player, address) && CMPHelper.isWithinRange(player.blockPosition(), this.getBlockPos())) {
                 sendToPlayer(player, itemStack, slot);
                 return;
             }
@@ -277,32 +345,11 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
 
         // Check if the item can be sent to another drone port.
         if (CMPConfigs.server().portToPort.get() && !PackageItem.matchAddress(address, addressFilter)) {
-            BeePortBlockEntity beePortBlockEntity = CMPHelper.getClosestBeePort(level, address, this.getBlockPos(), null);
+            BeePortBlockEntity beePortBlockEntity = CMPHelper.getClosestBeePort(level, address, this.getBlockPos(), null, getLogisticsNetworkId());
             if (beePortBlockEntity != null && !beePortBlockEntity.isFull()) {
                 sendDrone(itemStack, slot);
             }
         }
-    }
-
-    public static boolean doesAddressStringMatchPlayerName(Player player, String address) {
-        String playerName = player.getName().getString();
-        int atIndex = address.lastIndexOf('@');
-        if (atIndex == -1) {
-            return address.equals(playerName);
-        }
-        return address.substring(atIndex + 1).equals(playerName);
-    }
-
-    private static void requestRoboEntity(Level level, BlockPos blockPos) {
-        level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> {
-            List<BeePortBlockEntity> allBEs = new ArrayList<>(tracker.getAll());
-            allBEs.removeIf(BlockEntity::isRemoved);
-            allBEs.removeIf(be -> be.getBlockPos().equals(blockPos));
-            allBEs.removeIf(be -> be.getRoboBeeInventory().getStackInSlot(0).getCount() <= 0);
-            allBEs.stream()
-                    .min(Comparator.comparingDouble(a -> a.getBlockPos().distSqr(blockPos)))
-                    .ifPresent(target -> target.sendDrone(blockPos, true));
-        });
     }
 
     /**
@@ -315,7 +362,7 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     private void sendToPlayer(Player player, ItemStack itemStack, int slot) {
         if (roboBeeInventory.getStackInSlot(0).getCount() <= 0) {
             if (this.getRoboEntity() == null && level != null) {
-                requestRoboEntity(level, this.getBlockPos());
+                requestRoboEntity(level, this.getBlockPos(), this.getLogisticsNetworkId());
                 return;
             }
             return;
@@ -334,29 +381,29 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     private void sendDrone(ItemStack itemStack, int slot) {
         if (!tryConsumeDrone()) {
             if (this.getRoboEntity() == null && level != null) {
-                requestRoboEntity(level, this.getBlockPos());
+                requestRoboEntity(level, this.getBlockPos(), this.getLogisticsNetworkId());
                 return;
             }
             return;
         }
         sendItemThisTime = 2;
         if (level instanceof ServerLevel serverLevel) {
-            RoboManager.get(serverLevel).newRobo(serverLevel, itemStack, this.getBlockPos(), null, this.logisticsNetworkId, false);
+            RoboManager.get(serverLevel).newRobo(serverLevel, itemStack, this.getBlockPos(), null, this.getLogisticsNetworkId(), false);
         }
         inventory.setStackInSlot(slot, ItemStack.EMPTY);
     }
+
     private void sendDrone(BlockPos tagetPos, boolean request) {
-        if (!tryConsumeDrone())
-            return;
+        if (!tryConsumeDrone()) return;
         sendItemThisTime = 2;
         if (level instanceof ServerLevel serverLevel) {
-            RoboManager.get(serverLevel).newRobo(serverLevel, ItemStack.EMPTY, this.getBlockPos(), tagetPos, this.logisticsNetworkId, request);
+            RoboManager.get(serverLevel).newRobo(serverLevel, ItemStack.EMPTY, this.getBlockPos(), tagetPos, this.getLogisticsNetworkId(), request);
         }
     }
 
     /**
      * Tries to remove a drone from the inventory.
-     * 
+     *
      * @return whether a drone was available
      */
     private boolean tryConsumeDrone() {
@@ -365,29 +412,14 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     }
 
     /**
-     * Sets the open state of the drone port and updates the block state and sound.
-     *
-     * @param entity The drone port entity.
-     * @param open   Whether the port is open.
-     */
-    public static void setOpen(BeePortBlockEntity entity, boolean open) {
-        if (entity == null || entity.level == null) return;
-
-        entity.level.setBlockAndUpdate(entity.getBlockPos(), entity.getBlockState().setValue(IS_OPEN_TEXTURE, open));
-        entity.level.playSound(null, entity.getBlockPos(), open ? SoundEvents.BARREL_OPEN : SoundEvents.BARREL_CLOSE,
-                SoundSource.BLOCKS);
-
-    }
-
-    /**
      * Adds a Create Mod package to the inventory if there is space.
      *
      * @param itemStack The Create Mod package to add.
      * @return True if the package was added, false otherwise.
      */
-    public boolean addItemStack(ItemStack itemStack){
+    public boolean addItemStack(ItemStack itemStack) {
         for (int i = 0; i < inventory.getSlots(); i++) {
-            if (inventory.getStackInSlot(i).isEmpty()){
+            if (inventory.getStackInSlot(i).isEmpty()) {
                 inventory.insertItem(i, itemStack, false);
                 return true;
             }
@@ -396,43 +428,15 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
     }
 
     /**
-     * Checks if the player's inventory is full.
-     *
-     * @param player The player to check.
-     * @return True if the inventory is full, false otherwise.
-     */
-    public static boolean isPlayerInventoryFull(Player player) {
-        return player.getInventory().items.stream().limit(player.getInventory().getContainerSize() - 5).noneMatch(ItemStack::isEmpty);
-    }
-
-/**
- * Sends a Create Mod package to a player. If the player's inventory is full, the item is not added.
- *
- * @param player    The player to send the package to. Must not be null.
- * @param itemStack The Create Mod package to send. Must not be empty.
- * @return True if the package was successfully sent to the player, false otherwise.
- */
-public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
-    if (player == null || itemStack.isEmpty()) {
-        return false;
-    }
-    player.displayClientMessage(Component.translatableWithFallback("create_mobile_packages.bee_port.send_items", "Send Items to Player"), true);
-
-    if (isPlayerInventoryFull(player)) {
-        return false;
-    }
-    player.getInventory().add(itemStack);
-    return true;
-}
-
-    /**
      * Handles changes to the open state of the drone port.
      *
      * @param open Whether the port is open.
      */
     @Override
     protected void onOpenChange(boolean open) {
-        if (level == null) { return; }
+        if (level == null) {
+            return;
+        }
         level.playSound(null, worldPosition, open ? SoundEvents.BARREL_OPEN : SoundEvents.BARREL_CLOSE, SoundSource.BLOCKS);
         setOpen(this, open);
     }
@@ -443,7 +447,7 @@ public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
     @Override
     public void onLoad() {
         super.onLoad();
-        if (level != null && !level.isClientSide){
+        if (level != null && !level.isClientSide) {
             level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> tracker.add(this));
         }
     }
@@ -452,9 +456,7 @@ public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
      * Unregisters the entity from the tracker and halts any incoming bees.
      */
     private void invalidateTarget() {
-        level
-            .getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP)
-            .ifPresent(tracker -> tracker.remove(this));
+        level.getCapability(ModCapabilities.BEE_PORT_ENTITY_TRACKER_CAP).ifPresent(tracker -> tracker.remove(this));
 
         VirtualRobo currentEntity = getRoboEntity();
         if (currentEntity != null) {
@@ -471,13 +473,7 @@ public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
         ItemStack bees = roboBeeInventory.getStackInSlot(0);
 
         if (bees.getCount() > 0) {
-            level.addFreshEntity(new ItemEntity(
-                level,
-                worldPosition.getX(),
-                worldPosition.getY(),
-                worldPosition.getZ(),
-                bees
-            ));
+            level.addFreshEntity(new ItemEntity(level, worldPosition.getX(), worldPosition.getY(), worldPosition.getZ(), bees));
         }
     }
 
@@ -573,7 +569,7 @@ public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
         return BeePortMenu.create(pContainerId, pPlayerInventory, this);
     }
 
-    public VirtualRobo getRoboEntity(){
+    public VirtualRobo getRoboEntity() {
         if (level == null || entityOnTravelID == null) return null;
         if (level instanceof ServerLevel serverLevel) {
             return RoboManager.get(serverLevel).robos.get(entityOnTravelID);
@@ -591,5 +587,9 @@ public static boolean sendPackageToPlayer(Player player, ItemStack itemStack) {
 
     public ContainerData getData() {
         return data;
+    }
+
+    public UUID getLogisticsNetworkId() {
+        return behaviour.freqId;
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortBlockEntity.java
@@ -20,6 +20,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -591,5 +592,13 @@ public class BeePortBlockEntity extends PackagePortBlockEntity {
 
     public UUID getLogisticsNetworkId() {
         return behaviour.freqId;
+    }
+
+    @Override
+    public InteractionResult use(Player player) {
+        if (!behaviour.mayInteractMessage(player)) {
+            return InteractionResult.SUCCESS;
+        }
+        return super.use(player);
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortEntityTracker.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/BeePortEntityTracker.java
@@ -1,8 +1,8 @@
 package de.theidler.create_mobile_packages.blocks.bee_port;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 public class BeePortEntityTracker implements IBeePortEntityTracker {
     private final List<BeePortBlockEntity> list = new ArrayList<>();
@@ -17,8 +17,24 @@ public class BeePortEntityTracker implements IBeePortEntityTracker {
         list.remove(dpbe);
     }
 
+    /**
+     * Get all BeePortBlockEntities grouped by logistics network.
+     *
+     * @return A map of UUIDs to lists of BeePortBlockEntities.
+     */
     @Override
     public List<BeePortBlockEntity> getAll() {
-        return Collections.unmodifiableList(list);
+        return List.copyOf(list);
+    }
+
+    /**
+     * Get all BeePortBlockEntities for a given logistics network.
+     *
+     * @param logisticsNetworkId The UUID of the logistics network.
+     * @return A list of BeePortBlockEntities.
+     */
+    @Override
+    public List<BeePortBlockEntity> getAllByNetwork(UUID logisticsNetworkId) {
+        return list.stream().filter(dpbe -> dpbe.getLogisticsNetworkId().equals(logisticsNetworkId)).toList();
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/IBeePortEntityTracker.java
+++ b/src/main/java/de/theidler/create_mobile_packages/blocks/bee_port/IBeePortEntityTracker.java
@@ -1,10 +1,15 @@
 package de.theidler.create_mobile_packages.blocks.bee_port;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface IBeePortEntityTracker {
     void add(BeePortBlockEntity dpbe);
+
     void remove(BeePortBlockEntity dpbe);
+
     List<BeePortBlockEntity> getAll();
+
+    List<BeePortBlockEntity> getAllByNetwork(UUID logisticsNetworkId);
 }
 

--- a/src/main/java/de/theidler/create_mobile_packages/index/CMPBlockEntities.java
+++ b/src/main/java/de/theidler/create_mobile_packages/index/CMPBlockEntities.java
@@ -1,16 +1,8 @@
 package de.theidler.create_mobile_packages.index;
 
-import com.simibubi.create.content.logistics.packagePort.PackagePortBlockEntity;
 import com.tterrag.registrate.util.entry.BlockEntityEntry;
 import de.theidler.create_mobile_packages.CreateMobilePackages;
 import de.theidler.create_mobile_packages.blocks.bee_port.BeePortBlockEntity;
-import net.minecraft.core.BlockPos;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraftforge.common.util.LazyOptional;
 
 public class CMPBlockEntities {
 
@@ -19,52 +11,6 @@ public class CMPBlockEntities {
             .validBlocks(CMPBlocks.BEE_PORT)
             .register();
 
-    public static final BlockEntityEntry<DronePortBlockEntity> DRONE_PORT = CreateMobilePackages.REGISTRATE
-            .blockEntity("drone_port", DronePortBlockEntity::new)
-            .validBlocks(CMPBlocks.DRONE_PORT)
-            .register();
-
-
     public static void register() {
-    }
-
-    @Deprecated
-    public static class DronePortBlockEntity extends PackagePortBlockEntity {
-
-        public DronePortBlockEntity(BlockEntityType<?> pType, BlockPos pPos, BlockState pBlockState) {
-            super(pType, pPos, pBlockState);
-            itemHandler = LazyOptional.of(() -> inventory);
-        }
-
-        @Override
-        public void tick() {
-            if (!level.isClientSide) {
-                tryConvert(level, worldPosition);
-            }
-        }
-
-        public static void tryConvert(Level level, BlockPos pos) {
-            BlockEntity be = level.getBlockEntity(pos);
-            if (!(be instanceof DronePortBlockEntity dummy)) return;
-
-            // Save old data
-            CompoundTag data = new CompoundTag();
-            dummy.saveAdditional(data);
-
-            // Replace block
-            level.removeBlockEntity(pos);
-            level.setBlock(pos, CMPBlocks.BEE_PORT.get().defaultBlockState(), 3);
-
-            // Restore data to new block entity
-            BlockEntity newBe = level.getBlockEntity(pos);
-            if (newBe instanceof BeePortBlockEntity beePort) {
-                beePort.load(data);
-            }
-        }
-
-        @Override
-        protected void onOpenChange(boolean open) {
-
-        }
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/index/CMPBlocks.java
+++ b/src/main/java/de/theidler/create_mobile_packages/index/CMPBlocks.java
@@ -1,28 +1,14 @@
 package de.theidler.create_mobile_packages.index;
 
 import com.simibubi.create.AllTags;
-import com.simibubi.create.foundation.block.IBE;
+import com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBlockItem;
 import com.simibubi.create.foundation.data.SharedProperties;
 import com.tterrag.registrate.util.entry.BlockEntry;
 import de.theidler.create_mobile_packages.CreateMobilePackages;
 import de.theidler.create_mobile_packages.blocks.bee_port.BeePortBlock;
-import net.minecraft.core.BlockPos;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.BlockItem;
-import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.entity.BlockEntityType;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.StateDefinition;
 
 import static com.simibubi.create.api.behaviour.display.DisplaySource.displaySource;
 import static com.simibubi.create.foundation.data.ModelGen.customItemModel;
-import static de.theidler.create_mobile_packages.blocks.bee_port.BeePortBlock.IS_OPEN_TEXTURE;
 
 
 public class CMPBlocks {
@@ -32,65 +18,10 @@ public class CMPBlocks {
                     .tag(AllTags.AllBlockTags.SAFE_NBT.tag)
                     .transform(displaySource(CMPDisplaySources.BEE_COUNT))
                     .transform(displaySource(CMPDisplaySources.BEE_ETA))
-                    .item()
+                    .item(LogisticallyLinkedBlockItem::new)
                     .transform(customItemModel())
                     .register();
 
-    public static final BlockEntry<DronePortBlock> DRONE_PORT = CreateMobilePackages.REGISTRATE.block("drone_port", DronePortBlock::new)
-            .initialProperties(SharedProperties::wooden)
-            .tag(AllTags.AllBlockTags.SAFE_NBT.tag)
-            .item(DronePortItem::new)
-            .removeTab(CreativeModeTabs.SEARCH)
-            .removeTab(ResourceKey.create(net.minecraft.core.registries.Registries.CREATIVE_MODE_TAB, CreateMobilePackages.asResource("create_mobile_packages_tab")))
-            .transform(customItemModel())
-            .register();
-
     public static void register() {
-    }
-
-    @Deprecated
-    public static class DronePortItem extends BlockItem {
-        public DronePortItem(Block pBlock, Properties pProperties) {
-            super(pBlock, pProperties);
-        }
-        @Override
-        public void inventoryTick(ItemStack stack, Level level, Entity entity, int slot, boolean selected) {
-            if (!level.isClientSide && entity instanceof Player player) {
-                ItemStack replacement = new ItemStack(CMPBlocks.BEE_PORT.asStack().getItem(), stack.getCount());
-                replacement.setTag(stack.getTag());
-                player.getInventory().setItem(slot, replacement);
-            }
-        }
-    }
-
-    @Deprecated
-    public static class DronePortBlock extends Block implements IBE<CMPBlockEntities.DronePortBlockEntity> {
-
-        public DronePortBlock(Properties pProperties) {
-            super(pProperties);
-        }
-
-        @Override
-        protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> pBuilder) {
-            super.createBlockStateDefinition(pBuilder);
-            pBuilder.add(IS_OPEN_TEXTURE);
-        }
-
-        @Override
-        public void onPlace(BlockState pState, Level pLevel, BlockPos pPos, BlockState pOldState, boolean pMovedByPiston) {
-            if (!pLevel.isClientSide) {
-                CMPBlockEntities.DronePortBlockEntity.tryConvert(pLevel, pPos);
-            }
-        }
-
-        @Override
-        public Class<CMPBlockEntities.DronePortBlockEntity> getBlockEntityClass() {
-            return CMPBlockEntities.DronePortBlockEntity.class;
-        }
-
-        @Override
-        public BlockEntityType<? extends CMPBlockEntities.DronePortBlockEntity> getBlockEntityType() {
-            return CMPBlockEntities.DRONE_PORT.get();
-        }
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/index/CMPItems.java
+++ b/src/main/java/de/theidler/create_mobile_packages/index/CMPItems.java
@@ -4,13 +4,6 @@ import com.tterrag.registrate.util.entry.ItemEntry;
 import de.theidler.create_mobile_packages.CreateMobilePackages;
 import de.theidler.create_mobile_packages.items.portable_stock_ticker.PortableStockTicker;
 import de.theidler.create_mobile_packages.items.robo_bee.RoboBeeItem;
-import net.minecraft.resources.ResourceKey;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.CreativeModeTabs;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.level.Level;
 
 
 public class CMPItems {
@@ -19,32 +12,10 @@ public class CMPItems {
             CreateMobilePackages.REGISTRATE.item("portable_stock_ticker", PortableStockTicker::new)
                     .register();
 
-    public static final ItemEntry<DroneController> DRONE_CONTROLLER =
-            CreateMobilePackages.REGISTRATE.item("drone_controller", DroneController::new)
-                    .removeTab(CreativeModeTabs.SEARCH)
-                    .removeTab(ResourceKey.create(net.minecraft.core.registries.Registries.CREATIVE_MODE_TAB, CreateMobilePackages.asResource("create_mobile_packages_tab")))
-                    .register();
-
     public static final ItemEntry<RoboBeeItem> ROBO_BEE =
             CreateMobilePackages.REGISTRATE.item("robo_bee",RoboBeeItem::new)
                     .register();
 
     public static void register() {
-    }
-
-    @Deprecated
-    public static class DroneController extends Item {
-        public DroneController(Properties properties) {
-            super(properties);
-        }
-
-        @Override
-        public void inventoryTick(ItemStack pStack, Level pLevel, Entity pEntity, int pSlotId, boolean pIsSelected) {
-            if (!pLevel.isClientSide && pEntity instanceof Player player) {
-                ItemStack replacement = new ItemStack(CMPItems.PORTABLE_STOCK_TICKER.get());
-                replacement.setTag(pStack.getTag()); // preserve NBT
-                player.getInventory().setItem(pSlotId, replacement);
-            }
-        }
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/items/robo_bee/RoboBeeItem.java
+++ b/src/main/java/de/theidler/create_mobile_packages/items/robo_bee/RoboBeeItem.java
@@ -49,7 +49,8 @@ public class RoboBeeItem extends StockCheckingItem {
         }
         if (level instanceof ServerLevel serverLevel) {
             UUID networkId = networkFromStack(context.getItemInHand());
-            RoboManager.get(serverLevel).newRobo(serverLevel, packageItem, pos, null, networkId != null ? networkId : UUID.randomUUID(), true);
+            UUID finalNetworkId = networkId != null ? networkId : UUID.randomUUID();
+            RoboManager.get(serverLevel).newRobo(serverLevel, packageItem, pos, null, finalNetworkId, true);
         }
         context.getItemInHand().shrink(1);
         return InteractionResult.SUCCESS;

--- a/src/main/java/de/theidler/create_mobile_packages/items/robo_bee/RoboBeeItem.java
+++ b/src/main/java/de/theidler/create_mobile_packages/items/robo_bee/RoboBeeItem.java
@@ -2,6 +2,7 @@ package de.theidler.create_mobile_packages.items.robo_bee;
 
 import com.simibubi.create.content.logistics.box.PackageItem;
 import de.theidler.create_mobile_packages.index.config.CMPConfigs;
+import de.theidler.create_mobile_packages.items.portable_stock_ticker.StockCheckingItem;
 import de.theidler.create_mobile_packages.robo.RoboManager;
 import net.minecraft.ChatFormatting;
 import net.minecraft.core.BlockPos;
@@ -11,7 +12,6 @@ import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.TooltipFlag;
 import net.minecraft.world.item.context.UseOnContext;
@@ -20,8 +20,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
+import java.util.UUID;
 
-public class RoboBeeItem extends Item {
+import static com.simibubi.create.content.logistics.packagerLink.LogisticallyLinkedBlockItem.networkFromStack;
+
+public class RoboBeeItem extends StockCheckingItem {
 
     public RoboBeeItem(Properties pProperties) {
         super(pProperties);
@@ -31,6 +34,7 @@ public class RoboBeeItem extends Item {
     public @NotNull InteractionResult useOn(UseOnContext context) {
         Level level = context.getLevel();
         if (level.isClientSide) return InteractionResult.SUCCESS;
+        if (super.useOn(context) != InteractionResult.PASS) return InteractionResult.SUCCESS;
 
         Player player = context.getPlayer();
         if (player == null) return InteractionResult.PASS;
@@ -39,19 +43,13 @@ public class RoboBeeItem extends Item {
         BlockPos pos = context.getClickedPos().relative(context.getClickedFace());
 
         ItemStack packageItem = ItemStack.EMPTY;
-        if (PackageItem.isPackage(offhandItem) && CMPConfigs.server().allowRoboBeeSpawnPackageTransport.get()){
+        if (PackageItem.isPackage(offhandItem) && CMPConfigs.server().allowRoboBeeSpawnPackageTransport.get()) {
             packageItem = offhandItem.copy();
             player.setItemInHand(InteractionHand.OFF_HAND, ItemStack.EMPTY);
         }
         if (level instanceof ServerLevel serverLevel) {
-            RoboManager.get(serverLevel).newRobo(
-                    serverLevel,
-                    packageItem,
-                    pos,
-                    null,
-                    null,
-                    true
-            );
+            UUID networkId = networkFromStack(context.getItemInHand());
+            RoboManager.get(serverLevel).newRobo(serverLevel, packageItem, pos, null, networkId != null ? networkId : UUID.randomUUID(), true);
         }
         context.getItemInHand().shrink(1);
         return InteractionResult.SUCCESS;

--- a/src/main/java/de/theidler/create_mobile_packages/robo/VirtualRobo.java
+++ b/src/main/java/de/theidler/create_mobile_packages/robo/VirtualRobo.java
@@ -66,8 +66,6 @@ public class VirtualRobo {
         if (level.getBlockEntity(spawnPos) instanceof BeePortBlockEntity dpbe) {
             startBeePortBlockEntity = dpbe;
         }
-        this.yaw = getSnapAngle(getAngleToTarget());
-        // don't fly out of the port if target is origin
         if (targetBlockEntity != null && targetBlockEntity.equals(startBeePortBlockEntity)) {
             setState(new LandingDescendFinishState());
             return;
@@ -143,7 +141,7 @@ public class VirtualRobo {
         if (targetBlockEntity == null || targetBlockEntity.isRemoved() || !targetBlockEntity.canAcceptEntity(this, !itemStack.isEmpty()) || !Objects.equals(activeTargetAddress, targetAddress)) {
             BeePortBlockEntity oldTarget = targetBlockEntity;
             activeTargetAddress = targetAddress;
-            targetBlockEntity = CMPHelper.getClosestBeePort(serverLevel, targetAddress, BlockPos.containing(currentPos), this);
+            targetBlockEntity = CMPHelper.getClosestBeePort(serverLevel, targetAddress, BlockPos.containing(currentPos), this, this.logisticsNetworkId);
             if (oldTarget != targetBlockEntity) {
                 if (oldTarget != null) {
                     oldTarget.trySetEntityOnTravel(null);
@@ -158,7 +156,7 @@ public class VirtualRobo {
         }
         if (!isRequest) {
             // Check if there is a new target block entity that is closer than the current one
-            BeePortBlockEntity newTargetBlockEntity = CMPHelper.getClosestBeePort(serverLevel, targetAddress, BlockPos.containing(currentPos), this);
+            BeePortBlockEntity newTargetBlockEntity = CMPHelper.getClosestBeePort(serverLevel, targetAddress, BlockPos.containing(currentPos), this, logisticsNetworkId);
             if (newTargetBlockEntity != null && newTargetBlockEntity != targetBlockEntity) {
                 if (targetBlockEntity != null) {
                     targetBlockEntity.trySetEntityOnTravel(null);


### PR DESCRIPTION
This pull-request adds support to link a bee port or a bee item to a create logistics network.

**Warning! This will break all existing ports. They need to be replaced to link to a logistics network!**

- link a bee port to a logistics network or place one to create a new one
- bees will only fly to bee ports within their network.
- the bee item can be linked to a logistics network
- if a bee item is not connected to a network, then the bee will fly to any port (closest)