### PR TITLE
Fix spacing issues in #311

### DIFF
--- a/src/main/java/de/theidler/create_mobile_packages/toast/ToastOverlayRenderer.java
+++ b/src/main/java/de/theidler/create_mobile_packages/toast/ToastOverlayRenderer.java
@@ -52,9 +52,10 @@ public class ToastOverlayRenderer {
         int toastWidth = 160;
         int screenWidth = mc.getWindow().getGuiScaledWidth();
         int screenHeight = mc.getWindow().getGuiScaledHeight();
+        double guiScale = mc.getWindow().getGuiScale();
         CMPClient.ToastCorner corner = clientConfig.getToastCorner();
-        int offsetX = clientConfig.toastOffsetX.get();
-        int offsetY = clientConfig.toastOffsetY.get();
+        int offsetX = (int) Math.round(clientConfig.toastOffsetX.get() / guiScale);
+        int offsetY = (int) Math.round(clientConfig.toastOffsetY.get() / guiScale);
 
         boolean alignRight = corner == CMPClient.ToastCorner.TOP_RIGHT || corner == CMPClient.ToastCorner.BOTTOM_RIGHT;
         boolean alignBottom = corner == CMPClient.ToastCorner.BOTTOM_RIGHT || corner == CMPClient.ToastCorner.BOTTOM_LEFT;
@@ -63,7 +64,7 @@ public class ToastOverlayRenderer {
         TOASTS.removeIf(toast -> toast.lastUpdate < System.currentTimeMillis() - toast.timeout); // Remove toasts older than timeout
 
         if (alignBottom) {
-            int y = screenHeight - offsetY;
+            int y = screenHeight - offsetY + 4;
             for (Toast toast : TOASTS) {
                 y -= toast.getHeightWithSpacing();
                 toast.draw(guiGraphics, x, y, toastWidth);


### PR DESCRIPTION
After doing a bit more testing I realized that in #311 the position offset of the toasts changed based on the GUI scale and extra gap was being added to bottom anchored positioning, this should fix both of those issues. Sorry about the extra PR; I didn't expect the first one I made to get merged 15 minutes after I posted it :sob: