### PR TITLE
feat: Visual revamp of toast notifications

### DIFF
--- a/src/main/java/de/theidler/create_mobile_packages/toast/Toast.java
+++ b/src/main/java/de/theidler/create_mobile_packages/toast/Toast.java
@@ -21,7 +21,6 @@ public abstract class Toast {
     private final UUID id;
     public final long lastUpdate = System.currentTimeMillis();
     public final int timeout;
-    protected int backgroundColor = 0xAA000000;
     protected int height = 32;
 
     protected Toast(UUID id, int timeout) {
@@ -66,8 +65,23 @@ public abstract class Toast {
      * @return height of the toast
      */
     public int draw(GuiGraphics guiGraphics, int x, int y, int toastWidth) {
-        // Draw background rectangle
-        guiGraphics.fill(x, y, x + toastWidth, y + height, backgroundColor);
+        int h = height;
+
+        // Outer dark border
+        guiGraphics.fill(x, y, x + toastWidth, y + h,0xB3111111);
+        // Main background
+        guiGraphics.fill(x + 1,y + 1,x + toastWidth - 1,y + height - 1,0xB31D1D1D);
+        // Top highlight edge
+        guiGraphics.fill(x + 1,y + 1, x + toastWidth - 1, y + 2,0xB3444444);
+        // Inner inset shadow (bottom + right)
+        guiGraphics.fill(x + 1, y + h - 2, x + toastWidth - 1, y + h - 1, 0xB3111111);
+        guiGraphics.fill(x + toastWidth - 2, y + 1, x + toastWidth - 1, y + h - 1, 0xB3111111);
+        // Left accent bar
+        guiGraphics.fill(x + 1, y + 1, x + 3, y + h - 1,0xB3C8930A);
+        // Bottom accent bar
+        guiGraphics.fill(x + 3, y + h - 2, x + toastWidth - 1, y + h - 1, 0xB3C8930A);
+
+
         return getHeightWithSpacing();
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/toast/types/PackageToast.java
+++ b/src/main/java/de/theidler/create_mobile_packages/toast/types/PackageToast.java
@@ -3,6 +3,7 @@ package de.theidler.create_mobile_packages.toast.types;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
 import de.theidler.create_mobile_packages.index.CMPToasts;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.RegistryFriendlyByteBuf;
 import net.minecraft.network.chat.Component;
@@ -19,8 +20,10 @@ public class PackageToast extends SimpleToast {
 
     public PackageToast(UUID uuid, Component title, Component subtitle, ItemStack icon, List<ItemStack> items, int timeout) {
         super(uuid, title, subtitle, icon, timeout);
-        this.items = items;
-        height = 50;
+        this.items = items.stream()
+                .filter(s -> !s.isEmpty())
+                .collect(java.util.stream.Collectors.toList());
+        height = items.isEmpty() ? 32 : 52;
     }
 
     public PackageToast(UUID uuid, Component title, Component subtitle, ItemStack icon, List<ItemStack> items) {
@@ -57,16 +60,49 @@ public class PackageToast extends SimpleToast {
     @Override
     public int draw(GuiGraphics guiGraphics, int x, int y, int toastWidth) {
         int heightWithSpacing = super.draw(guiGraphics, x, y, toastWidth);
-        int spacing = toastWidth / items.size();
-        // Draw Items
-        for (int i = 0; i < items.size(); i++) {
-            ItemStack item = items.get(i);
-            guiGraphics.renderItem(item, x + (i*spacing)+4, y + 30);
 
-            guiGraphics.pose().pushPose();
-            guiGraphics.pose().translate(0, 0, 200);
-            drawItemCount(guiGraphics, item.getCount(),x + (i*spacing)+4, y + 30 );
-            guiGraphics.pose().popPose();
+        guiGraphics.fill(x + 4, y + 28, x + toastWidth - 4, y + 29, 0xFF2F2F2F);
+
+        int slotSize = 16;
+        int slotGap = 3;
+        int startX = x + 5;
+        int slotY = y + 31;
+        boolean hasOverflow = items.size() > 8;
+        int maxVisible = hasOverflow ? 7 : 8;
+
+        for (int i = 0; i < 8; i++) {
+            int sx = startX + i * (slotSize + slotGap);
+
+            guiGraphics.fill(sx - 1, slotY - 1, sx + slotSize, slotY + slotSize, 0xFF2A2A2A);
+            guiGraphics.fill(sx - 1, slotY - 1, sx + slotSize, slotY, 0xFF3A3A3A);
+
+            if (i < Math.min(items.size(), maxVisible)) {
+                ItemStack item = items.get(i);
+                guiGraphics.renderItem(item, sx, slotY);
+
+                guiGraphics.pose().pushPose();
+                guiGraphics.pose().translate(0, 0, 200);
+                drawItemCount(guiGraphics, item.getCount(), sx, slotY);
+                guiGraphics.pose().popPose();
+            }
+        }
+
+        if (hasOverflow) {
+            int overflow = items.size() - maxVisible;
+            int sx = startX + maxVisible * (slotSize + slotGap);
+
+            guiGraphics.fill(sx + 3, slotY + 1, sx + slotSize + 3, slotY + slotSize + 1, 0xFF1A1A1A);
+            guiGraphics.fill(sx + 1, slotY + 1, sx + slotSize + 1, slotY + slotSize + 1, 0xFF222200);
+            guiGraphics.fill(sx - 1, slotY - 1, sx + slotSize, slotY + slotSize, 0xFF3D2E00);
+            guiGraphics.fill(sx - 1, slotY - 1, sx + slotSize, slotY, 0xFF5A4500);
+            guiGraphics.fill(sx - 1, slotY - 1, sx + 1, slotY + slotSize, 0xFFC8930A);
+
+            String overflowText = "+" + overflow;
+            int textWidth = Minecraft.getInstance().font.width(overflowText);
+            guiGraphics.drawString(Minecraft.getInstance().font, overflowText,
+                    sx + (slotSize / 2) - (textWidth / 2),
+                    slotY + (slotSize / 2) - 4,
+                    0xF5C842, false);
         }
 
         return heightWithSpacing;

--- a/src/main/java/de/theidler/create_mobile_packages/toast/types/SimpleToast.java
+++ b/src/main/java/de/theidler/create_mobile_packages/toast/types/SimpleToast.java
@@ -54,12 +54,11 @@ public class SimpleToast extends Toast {
         int heightWithSpacing = super.draw(guiGraphics, x, y, toastWidth);
 
         // Draw icon
-        guiGraphics.renderItem(this.icon, x + 6, y + 6);
+        guiGraphics.renderItem(this.icon, x + 5, y + 6);
         // Draw title
-        guiGraphics.drawString(mc.font, this.title, x + 28, y + 6, 0xFFFFFF, false);
+        guiGraphics.drawString(mc.font, this.title, x + 22, y + 6, 0xFFFFFF, false);
         // Draw subtitle
-        guiGraphics.drawString(mc.font, this.subtitle, x + 28, y + 18, 0xAAAAAA, false);
-
+        guiGraphics.drawString(mc.font, this.subtitle, x + 22, y + 18, 0xAAAAAA, false);
         return heightWithSpacing;
     }
 }


### PR DESCRIPTION
Tried a revamp of the toast notifications, they felt a bit out of place with the rest of the visuals.
If refused, no harm done!

With less than 8 items.
<img width="798" height="263" alt="image" src="https://github.com/user-attachments/assets/5a4d724c-c853-43e8-86c6-5cb72250b887" />

More than 8 items. (9 in this case, 7 rendered + 2)
<img width="808" height="272" alt="image" src="https://github.com/user-attachments/assets/57fbb450-485b-4379-9c75-0de6ec70abf9" />
