### PR TITLE
Fix the toast

### DIFF
--- a/src/main/java/de/theidler/create_mobile_packages/compat/fluidlogistics/CFLBridge.java
+++ b/src/main/java/de/theidler/create_mobile_packages/compat/fluidlogistics/CFLBridge.java
@@ -7,8 +7,11 @@ import com.yision.fluidlogistics.item.CompressedTankItem;
 import com.yision.fluidlogistics.registry.AllItems;
 import com.yision.fluidlogistics.util.FluidAmountHelper;
 import com.yision.fluidlogistics.util.IFluidCraftableBigItemStack;
+import com.yision.fluidlogistics.util.VirtualFluidDisplayHelper;
 import net.minecraft.world.item.ItemStack;
+import net.neoforged.neoforge.capabilities.Capabilities;
 import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.capability.IFluidHandlerItem;
 import ru.zznty.create_factory_abstractions.api.generic.stack.GenericStack;
 import ru.zznty.create_factory_abstractions.generic.support.BigGenericStack;
 import ru.zznty.create_factory_abstractions.generic.support.GenericOrder;
@@ -114,5 +117,19 @@ public class CFLBridge {
 
     public static ItemStack keyAsItemStack(GenericStack stack) {
         return BigGenericStack.of(stack.withAmount(1)).asStack().stack;
+    }
+
+    public static boolean shouldDisplayAsFluidInPackage(ItemStack stack) {
+        return VirtualFluidDisplayHelper.shouldDisplayAsFluidInPackage(stack)
+                && getPackageFluidAmount(stack) > 0;
+    }
+
+    public static int getPackageFluidAmount(ItemStack stack) {
+        IFluidHandlerItem handler = stack.getCapability(Capabilities.FluidHandler.ITEM);
+        if (handler == null || handler.getTanks() <= 0) {
+            return 0;
+        }
+        FluidStack fluid = handler.getFluidInTank(0);
+        return fluid.isEmpty() ? 0 : fluid.getAmount();
     }
 }

--- a/src/main/java/de/theidler/create_mobile_packages/compat/fluidlogistics/CFLClientBridge.java
+++ b/src/main/java/de/theidler/create_mobile_packages/compat/fluidlogistics/CFLClientBridge.java
@@ -1,0 +1,19 @@
+package de.theidler.create_mobile_packages.compat.fluidlogistics;
+
+import com.yision.fluidlogistics.render.FluidSlotAmountRenderer;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.item.ItemStack;
+
+public class CFLClientBridge {
+
+    public static void renderPackageFluidAmount(GuiGraphics graphics, ItemStack stack, int itemX, int itemY) {
+        int amount = CFLBridge.getPackageFluidAmount(stack);
+        if (amount <= 0) {
+            return;
+        }
+        graphics.pose().pushPose();
+        graphics.pose().translate(itemX, itemY, 0);
+        FluidSlotAmountRenderer.renderInStockKeeper(graphics, amount);
+        graphics.pose().popPose();
+    }
+}

--- a/src/main/java/de/theidler/create_mobile_packages/toast/types/PackageToast.java
+++ b/src/main/java/de/theidler/create_mobile_packages/toast/types/PackageToast.java
@@ -2,6 +2,9 @@ package de.theidler.create_mobile_packages.toast.types;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.simibubi.create.foundation.gui.AllGuiTextures;
+import de.theidler.create_mobile_packages.compat.Mods;
+import de.theidler.create_mobile_packages.compat.fluidlogistics.CFLBridge;
+import de.theidler.create_mobile_packages.compat.fluidlogistics.CFLClientBridge;
 import de.theidler.create_mobile_packages.index.CMPToasts;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.RegistryFriendlyByteBuf;
@@ -61,11 +64,18 @@ public class PackageToast extends SimpleToast {
         // Draw Items
         for (int i = 0; i < items.size(); i++) {
             ItemStack item = items.get(i);
-            guiGraphics.renderItem(item, x + (i*spacing)+4, y + 30);
+            int itemX = x + (i * spacing) + 4;
+            int itemY = y + 30;
+            guiGraphics.renderItem(item, itemX, itemY);
 
             guiGraphics.pose().pushPose();
             guiGraphics.pose().translate(0, 0, 200);
-            drawItemCount(guiGraphics, item.getCount(),x + (i*spacing)+4, y + 30 );
+            if (Mods.FLUIDLOGISTICS.isLoaded()
+                    && CFLBridge.shouldDisplayAsFluidInPackage(item)) {
+                CFLClientBridge.renderPackageFluidAmount(guiGraphics, item, itemX, itemY);
+            } else {
+                drawItemCount(guiGraphics, item.getCount(), itemX, itemY);
+            }
             guiGraphics.pose().popPose();
         }
 


### PR DESCRIPTION
Fix the toast showing 1 as the Fluid amount independent of the actual amount. Sorry, I forgot to add fluidlogistics compatibility for toast yesterday. In addition, the factorylogistics has been archived. Will you consider adding fluidlogistics to the optional dependencies of CMP.
<img width="644" height="207" alt="PixPin_2026-05-08_13-15-14" src="https://github.com/user-attachments/assets/2f64f91a-26c5-4590-8a66-a843ee067089" />
